### PR TITLE
update godoc url

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ This tutorial deals with tricks for making your godoc organized and neat.
 This is a compilation of tricks I've collected and couldn't find a
 comprehensive guide for.
 
-The doc can be found at: [godoc-tricks](https://godoc.org/github.com/fluhus/godoc-tricks)
+The doc can be found at: [godoc-tricks](https://pkg.go.dev/github.com/fluhus/godoc-tricks)


### PR DESCRIPTION
godoc.org is deprecated, this uses the new url