### PR TITLE
add interface example

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -218,3 +218,10 @@ type Bugs int
 //
 // [other unicode characters]: https://go.dev/doc/comment#lists
 type Lists int
+
+// Interface are rendered like Struct:
+//   - exported methods are shown (with comments)
+//   - unexported methods are hidden
+type Interface interface {
+	Method()
+}


### PR DESCRIPTION
Related to https://github.com/fluhus/godoc-tricks/issues/9

Add a simple `type Interface interface{...}` type.