### PR TITLE
add whole file examples

### DIFF
--- a/example_pkg_test.go
+++ b/example_pkg_test.go
@@ -1,0 +1,13 @@
+package godoctricks_test
+
+import "fmt"
+
+var message = "Hello"
+
+// A whole file example is a file that ends in `_test.go` and contains exactly one
+// example function, no test or benchmark functions, and at least one other
+// package-level declaration.
+func Example_wholeFilePackage() {
+	fmt.Println(message)
+	// Output: Hello
+}

--- a/example_type_test.go
+++ b/example_type_test.go
@@ -1,0 +1,15 @@
+package godoctricks_test
+
+import "fmt"
+
+var messageExample = "Hello"
+
+// A whole file example can also be attached to a given type (Examples here)
+// with appropriate naming.
+//
+// A whole file example is a file that ends in `_test.go` and contains exactly one
+// example function, no test or benchmark functions, and at least one other
+// package-level declaration.
+func ExampleExamples_wholeFileType() {
+	fmt.Println(messageExample)
+}


### PR DESCRIPTION
Related to https://github.com/fluhus/godoc-tricks/issues/9

Add two "whole file" examples (at the package and type level).