### PR TITLE
More examples (at different levels)

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -107,9 +107,11 @@ const (
 //
 // The example functions should be called Example() for
 // package examples, ExampleTypename() for a specific type or
-// ExampleFuncname() for a specific function. For multiple examples
-// for the same entity (like same function), you can add a suffix like
-// ExampleFoo_suffix1, ExampleFoo_suffix2.
+// ExampleFuncname() for a specific function, ExampleTypename_Methodname() for
+// a method on a specific type.
+//
+// For multiple examples for the same entity (like same function), you can add
+// a suffix starting with a lowercase like ExampleFoo_suffix1, ExampleFoo_suffix2.
 //
 // You can document an example's output, by adding an output comment at its end.
 // The output comment must begin with "Output:", as shown below:
@@ -129,6 +131,11 @@ type Examples int
 // NewExamples is a func with an associated example. See [Examples] regarding the details.
 func NewExamples() Examples {
 	return 0
+}
+
+// ExampleMethod is a method with an associated example. See [Examples] regarding the details.
+func (e Examples) ExampleMethod() int {
+	return int(e)
 }
 
 // FuncExampleWithoutType is a func with an associated example (but not associated type).

--- a/doc.go
+++ b/doc.go
@@ -131,6 +131,12 @@ func NewExamples() Examples {
 	return 0
 }
 
+// FuncExampleWithoutType is a func with an associated example (but not associated type).
+// See [Examples] regarding the details.
+func FuncExampleWithoutType() int {
+	return 0
+}
+
 // You can embed blocks of code in your godoc, such as this:
 //
 //	fmt.Println("Hello")

--- a/doc.go
+++ b/doc.go
@@ -126,6 +126,11 @@ const (
 // http://golang.org/pkg/testing/
 type Examples int
 
+// NewExamples is a func with an associated example. See [Examples] regarding the details.
+func NewExamples() Examples {
+	return 0
+}
+
 // You can embed blocks of code in your godoc, such as this:
 //
 //	fmt.Println("Hello")

--- a/doc_test.go
+++ b/doc_test.go
@@ -40,6 +40,13 @@ func ExampleNewExamples() {
 	fmt.Println("Hello", NewExamples())
 }
 
+// This function is named ExampleExamples_ExampleMethod(), this way godoc knows to associate
+// it with the ExampleMethod method of the Examples type.
+func ExampleExamples_ExampleMethod() {
+	e := Examples(42)
+	fmt.Println("Hello", e.ExampleMethod())
+}
+
 // This function is named ExampleFuncExampleWithoutType(), this way godoc knows to associate
 // it with the FuncExampleWithoutType func.
 func ExampleFuncExampleWithoutType() {

--- a/doc_test.go
+++ b/doc_test.go
@@ -39,3 +39,9 @@ func ExampleExamples_output() {
 func ExampleNewExamples() {
 	fmt.Println("Hello", NewExamples())
 }
+
+// This function is named ExampleFuncExampleWithoutType(), this way godoc knows to associate
+// it with the FuncExampleWithoutType func.
+func ExampleFuncExampleWithoutType() {
+	fmt.Println("Hello", FuncExampleWithoutType())
+}

--- a/doc_test.go
+++ b/doc_test.go
@@ -33,3 +33,9 @@ func ExampleExamples_output() {
 	fmt.Println("Hello")
 	// Output: Hello
 }
+
+// This function is named ExampleNewExamples(), this way godoc knows to associate
+// it with the NewExamples func.
+func ExampleNewExamples() {
+	fmt.Println("Hello", NewExamples())
+}


### PR DESCRIPTION
Related to #9

This adds examples at different levels (since they are stored on different [fields inside the `go/doc.Package` type](https://codeberg.org/pfad.fr/vanitydoc/src/commit/66eaf1e5136aed9972b75522ce44a8d617d7e38a/pkg/html.go#L160-L185)):
- A func returning a  local type
- A func not returning a local type
- A type method
