### PR TITLE
Add links to various documentation sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ godoc-tricks
 ============
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/fluhus/godoc-tricks.svg)](https://pkg.go.dev/github.com/fluhus/godoc-tricks)
+[![Go Documentation](https://godocs.io/github.com/fluhus/godoc-tricks?status.svg)](https://godocs.io/github.com/fluhus/godoc-tricks)
+[![Vanitydoc Refernce](https://code.pfad.fr/vanitydoc.svg)](https://code.pfad.fr/fluhus/godoc-tricks/)
 
 This is a guide on the features of GoDoc, to help everyone make the most
 out of this feature of Go.


### PR DESCRIPTION
Thanks to your package ([and some additions you accepted](https://github.com/fluhus/godoc-tricks/pulls?q=is%3Apr+is%3Aclosed+author%3Aoliverpool)), I was able to polish my [vanitydoc](https://code.pfad.fr/vanitydoc/) project.


I think it would be nice to link to different rendering of this package, so that the users can compare how all the godoc features are rendered.

Do you think that this is a sensible idea?

I have added https://godocs.io and vanitydoc. Do you know other rendering of this doc?
